### PR TITLE
Replace `Array#hash` with MD5

### DIFF
--- a/lib/flay.rb
+++ b/lib/flay.rb
@@ -6,6 +6,7 @@ require "sexp_processor"
 require "ruby_parser"
 require "timeout"
 require "concurrent"
+require "digest"
 
 class File
   RUBY19 = "<3".respond_to? :encoding unless defined? RUBY19 # :nodoc:
@@ -579,7 +580,7 @@ class Sexp
   # modify the sexp afterwards and expect it to be correct.
 
   def structural_hash
-    @structural_hash ||= self.structure.hash
+    @structural_hash ||= Digest::MD5.hexdigest(self.structure.to_s)
   end
 
   ##

--- a/test/test_flay.rb
+++ b/test/test_flay.rb
@@ -19,7 +19,8 @@ class TestSexp < Minitest::Test
     hash = s(:iter,
              s(:call, s(:arglist, s(:lit))),
              s(:lasgn),
-             s(:call, s(:arglist))).hash
+             s(:call, s(:arglist))).structural_hash
+
 
     assert_equal hash, @s.deep_clone.structural_hash
     assert_equal hash, @s.structural_hash
@@ -46,12 +47,12 @@ class TestSexp < Minitest::Test
           s(:call, s(:arglist)))
 
     expected = [
-                s[1]      .hash,
-                s[1][1]   .hash,
-                s[1][1][1].hash,
-                s[2]      .hash,
-                s[3]      .hash,
-                s[3][1]   .hash,
+                s[1]      .structural_hash,
+                s[1][1]   .structural_hash,
+                s[1][1][1].structural_hash,
+                s[2]      .structural_hash,
+                s[3]      .structural_hash,
+                s[3][1]   .structural_hash,
                ].sort
 
     assert_equal expected, @s.all_structural_subhashes.sort.uniq


### PR DESCRIPTION
Flay currently relies on the `Array#hash` method which differs between
Ruby implementations and can have hash collisions giving us false
positives.

Now instead of using `#hash` we MD5 the `to_s` value of the s-expression
which should have more consistent results across platforms and be much
less likely to collide.
