### PR TITLE
Use Concurrent::Hash, not Concurrent::Map

### DIFF
--- a/lib/flay.rb
+++ b/lib/flay.rb
@@ -215,7 +215,7 @@ class Flay
       hash[key] = Concurrent::Array.new
     end
 
-    self.identical      = Concurrent::Map.new
+    self.identical      = Concurrent::Hash.new
     self.masses         = Concurrent::Hash.new
     self.total          = 0
     self.mass_threshold = @option[:mass]


### PR DESCRIPTION
I suspect that our not-quite-deterministic engine behavior may be
attributable to this issue: https://github.com/ruby-concurrency/concurrent-ruby/issues/512.

It appears `Concurrent::Map` has a race condition. `Concurrent::Hash` is
implemented quite differently, & is theoretically not susceptible to the
same problem.

The downside of this switch is that `Map` has better concurrent
performance than `Hash`. `Hash`, according to the docs, "locks against
the object itself for every method call, ensuring only one thread can be
reading or writing at a time." `Map` is meant to be smarter about only
locking when it needs to. I'm not very concerned about this change: I
think most of the benefit we get from concurrency is at the parsing
stage.

This is just a guess, unfortunately, without any test cases to back it
up right now: we still haven't found a repo we can reliably get
different duplication results from.

@codeclimate/review I'm still trying to find a repo that I can observe the non-determinism on locally, but thoughts on this are appreciated.
